### PR TITLE
Add cluster-api-provider template

### DIFF
--- a/charts/cluster-api-provider-aws/.helmignore
+++ b/charts/cluster-api-provider-aws/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cluster-api-provider-aws/Chart.yaml
+++ b/charts/cluster-api-provider-aws/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cluster-api-provider-aws
+description: A Helm chart for Cluster API provider AWS
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.1.3
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.8.3"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-aws
+  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2

--- a/charts/cluster-api-provider-aws/templates/_helpers.tpl
+++ b/charts/cluster-api-provider-aws/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "featureGates.default" -}}
+ExternalResourceGC: true
+{{- end }}
+
+{{/*
+Merge .Values.manager.featureGates with the default
+*/}}
+{{- define "featureGates" -}}
+{{ toYaml (merge (.Values.manager.featureGates | default dict) (include "featureGates.default" . | fromYaml)) }}
+{{- end }}
+
+{{/*
+Manager settings with the default feature gates
+*/}}
+{{- define "spec.manager" -}}
+{{- $manager := deepCopy .Values.manager }}
+{{- $_ := set $manager "featureGates" (include "featureGates" . | fromYaml) }}
+{{- toYaml $manager }}
+{{- end }}

--- a/charts/cluster-api-provider-aws/templates/interface.yaml
+++ b/charts/cluster-api-provider-aws/templates/interface.yaml
@@ -1,0 +1,19 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ProviderInterface
+metadata:
+  name: cluster-api-provider-aws
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  clusterGVKs:
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1beta2
+      kind: AWSCluster
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1beta2
+      kind: AWSManagedCluster
+  clusterIdentityKinds:
+    - AWSClusterStaticIdentity
+    - AWSClusterRoleIdentity
+    - AWSClusterControllerIdentity
+  description: "AWS infrastructure provider for Cluster API"

--- a/charts/cluster-api-provider-aws/templates/provider.yaml
+++ b/charts/cluster-api-provider-aws/templates/provider.yaml
@@ -1,0 +1,28 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := .Chart.AppVersion }}
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: aws
+spec:
+  version: {{ $version }}
+  {{- if .Values.configSecret.name }}
+  configSecret:
+    name: {{ .Values.configSecret.name }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}
+  manager: {{ include "spec.manager" . | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-aws-components:{{ $version }}
+  {{- end }}
+  deployment:
+    containers:
+      - name: manager
+        {{- if $global.registry }}
+        imageUrl: {{ $global.registry }}/capi/cluster-api-aws-controller:{{ $version }}
+        {{- end }}
+        {{- with .Values.managerEnv }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}

--- a/charts/cluster-api-provider-aws/templates/secret.yaml
+++ b/charts/cluster-api-provider-aws/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.configSecret.create .Values.configSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.configSecret.name }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+stringData:
+{{ toYaml .Values.config | indent 2 }}
+{{- end }}

--- a/charts/cluster-api-provider-aws/values.schema.json
+++ b/charts/cluster-api-provider-aws/values.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-aws template",
+  "type": "object",
+  "properties": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "AWS_B64ENCODED_CREDENTIALS": {
+          "type": "string"
+        }
+      }
+    },
+    "configSecret": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "manager": {
+      "type": "object"
+    },
+    "managerEnv": {
+      "type": "array"
+    }
+  }
+}

--- a/charts/cluster-api-provider-aws/values.yaml
+++ b/charts/cluster-api-provider-aws/values.yaml
@@ -1,0 +1,10 @@
+configSecret:
+  create: true
+  name: "aws-variables"
+  namespace: ""
+
+config:
+  AWS_B64ENCODED_CREDENTIALS: Cg==
+
+manager: {}
+managerEnv: []


### PR DESCRIPTION
This adds custom cluster-api-provider-aws template which allows for controller's environment variables customization.

To add additional controller env variables (e.g. `HTTPS_PROXY`) the `managerEnv` value should be used. For example:

```yaml
managerEnv:
  - name: HTTPS_PROXY
    value: 127.0.0.1:3128
```

> [!NOTE]
> PR is in draft bacause even though env variables pass-trough works fine the fact that proxy configuration with the env vars applies and works as expected is untested.